### PR TITLE
Add `variable_is_lut` to WEBMIN

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -2559,7 +2559,7 @@ void CompilerHLSL::emit_resources()
 		end_scope();
 		statement("");
 	}
-	#endif
+#endif // SPIRV_CROSS_WEBMIN
 
 	for (TypeID type_id : composite_selection_workaround_types)
 	{
@@ -6473,6 +6473,20 @@ bool CompilerHLSL::is_per_primitive_variable(const SPIRVariable &var) const
 			return false;
 
 	return true;
+}
+
+bool CompilerHLSL::variable_is_lut(const SPIRVariable &var) const
+{
+	bool statically_assigned = var.statically_assigned && var.static_expression != ID(0) && var.remapped_variable;
+
+	if (statically_assigned)
+	{
+		auto *constant = maybe_get<SPIRConstant>(var.static_expression);
+		if (constant && constant->is_used_as_lut)
+			return true;
+	}
+
+	return false;
 }
 
 void CompilerHLSL::flush_variable_declaration(uint32_t id)
@@ -18055,20 +18069,6 @@ uint32_t CompilerHLSL::get_declared_member_location(const SPIRVariable &var, uin
 		return get_accumulated_member_location(var, mbr_idx, strip_array);
 }
 
-bool CompilerHLSL::variable_is_lut(const SPIRVariable &var) const
-{
-	bool statically_assigned = var.statically_assigned && var.static_expression != ID(0) && var.remapped_variable;
-
-	if (statically_assigned)
-	{
-		auto *constant = maybe_get<SPIRConstant>(var.static_expression);
-		if (constant && constant->is_used_as_lut)
-			return true;
-	}
-
-	return false;
-}
-
 void CompilerHLSL::emit_buffer_block_flattened(const SPIRVariable &var)
 {
 	auto &type = get<SPIRType>(var.basetype);
@@ -20512,12 +20512,6 @@ void CompilerHLSL::fixup_implicit_builtin_block_names(ExecutionModel)
 }
 
 uint32_t CompilerHLSL::get_declared_member_location(const SPIRVariable &, uint32_t, bool) const
-{
-	SPIRV_CROSS_INVALID_CALL();
-	SPIRV_CROSS_THROW("Invalid call.");
-}
-
-bool CompilerHLSL::variable_is_lut(const SPIRVariable &) const
 {
 	SPIRV_CROSS_INVALID_CALL();
 	SPIRV_CROSS_THROW("Invalid call.");

--- a/spirv_msl.cpp
+++ b/spirv_msl.cpp
@@ -14875,6 +14875,20 @@ void CompilerMSL::emit_function(SPIRFunction &func, const Bitset &return_flags)
 	}
 }
 
+bool CompilerMSL::variable_is_lut(const SPIRVariable &var) const
+{
+	bool statically_assigned = var.statically_assigned && var.static_expression != ID(0) && var.remapped_variable;
+
+	if (statically_assigned)
+	{
+		auto *constant = maybe_get<SPIRConstant>(var.static_expression);
+		if (constant && constant->is_used_as_lut)
+			return true;
+	}
+
+	return false;
+}
+
 bool CompilerMSL::is_stage_output_variable_masked(const SPIRVariable &var) const
 {
 	auto &type = get<SPIRType>(var.basetype);
@@ -27038,21 +27052,6 @@ void CompilerMSL::add_header_line(const std::string &line)
 	header_lines.push_back(line);
 }
 
-bool CompilerMSL::variable_is_lut(const SPIRVariable &var) const
-{
-	bool statically_assigned = var.statically_assigned && var.static_expression != ID(0) && var.remapped_variable;
-
-	if (statically_assigned)
-	{
-		auto *constant = maybe_get<SPIRConstant>(var.static_expression);
-		if (constant && constant->is_used_as_lut)
-			return true;
-	}
-
-	return false;
-}
-
-
 uint32_t CompilerMSL::get_declared_member_location(const SPIRVariable &var, uint32_t mbr_idx, bool strip_array) const
 {
 	auto &block_type = get<SPIRType>(var.basetype);
@@ -30417,7 +30416,7 @@ void CompilerMSL::set_fragment_output_components(uint32_t location, uint32_t com
 {
 	fragment_output_components[location] = components;
 }
-#else
+#else // SPIRV_CROSS_WEBMIN 
 void CompilerMSL::store_flattened_struct(const string &, uint32_t, const SPIRType &,
                                           const SmallVector<uint32_t> &)
 {
@@ -31046,13 +31045,6 @@ void CompilerMSL::add_header_line(const std::string &line)
 	SPIRV_CROSS_THROW("Invalid call.");
 }
 
-bool CompilerMSL::variable_is_lut(const SPIRVariable &) const
-{
-	SPIRV_CROSS_INVALID_CALL();
-	SPIRV_CROSS_THROW("Invalid call.");
-}
-
-
 uint32_t CompilerMSL::get_declared_member_location(const SPIRVariable &, uint32_t, bool) const
 {
 	SPIRV_CROSS_INVALID_CALL();
@@ -31627,4 +31619,4 @@ void CompilerMSL::set_fragment_output_components(uint32_t, uint32_t)
 	SPIRV_CROSS_INVALID_CALL();
 	SPIRV_CROSS_THROW("Invalid call.");
 }
-#endif
+#endif // SPIRV_CROSS_WEBMIN


### PR DESCRIPTION
`variable_is_lut` is being called in a number of scenarios. This change makes this function available even when `SPIRV_CROSS_WEBMIN` is enabled.