### PR TITLE
Fix CMake 4 error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 #  2. The MIT License, found at <http://opensource.org/licenses/MIT>.
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
CMake 4 issues an error when the cmake minimum required version is less than 3.5, and a warning when less than 3.10. This change increases the minimum CMake version to 3.10 to avoid the error and warning.