### PR TITLE
HLSL: expose image_type_hlsl stubs needed by Babylon Native shaders

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -20222,16 +20222,74 @@ CompilerHLSL::ShaderSubgroupSupportHelper::Result::Result()
 	SPIRV_CROSS_THROW("Invalid call.");
 }
 
-string CompilerHLSL::image_type_hlsl_legacy(const SPIRType &, uint32_t /*id*/)
+string CompilerHLSL::image_type_hlsl_legacy(const SPIRType &type, uint32_t /*id*/)
 {
-	SPIRV_CROSS_INVALID_CALL();
-	SPIRV_CROSS_THROW("Invalid call.");
+	auto &imagetype = get<SPIRType>(type.image.type);
+	string res;
+
+	switch (imagetype.basetype)
+	{
+	case SPIRType::Int:
+		res = "i";
+		break;
+	case SPIRType::UInt:
+		res = "u";
+		break;
+	default:
+		break;
+	}
+
+	if (type.basetype == SPIRType::Image && type.image.dim == DimSubpassData)
+		return res + "subpassInput" + (type.image.ms ? "MS" : "");
+
+	if (type.basetype == SPIRType::Image && type.image.dim != DimSubpassData)
+	{
+		if (type.image.dim == DimBuffer && type.image.sampled == 1)
+			res += "sampler";
+		else
+			res += type.image.sampled == 2 ? "image" : "texture";
+	}
+	else
+		res += "sampler";
+
+	switch (type.image.dim)
+	{
+	case Dim1D:
+		res += "1D";
+		break;
+	case Dim2D:
+		res += "2D";
+		break;
+	case Dim3D:
+		res += "3D";
+		break;
+	case DimCube:
+		res += "CUBE";
+		break;
+	case DimBuffer:
+		res += "Buffer";
+		break;
+	case DimSubpassData:
+		res += "2D";
+		break;
+	default:
+		SPIRV_CROSS_THROW("Only 1D, 2D, 3D, Buffer, InputTarget and Cube textures supported.");
+	}
+
+	if (type.image.ms)
+		res += "MS";
+	if (type.image.arrayed)
+		res += "Array";
+
+	return res;
 }
 
-string CompilerHLSL::image_type_hlsl(const SPIRType &, uint32_t)
+string CompilerHLSL::image_type_hlsl(const SPIRType &type, uint32_t id)
 {
-	SPIRV_CROSS_INVALID_CALL();
-	SPIRV_CROSS_THROW("Invalid call.");
+	if (hlsl_options.shader_model <= 30)
+		return image_type_hlsl_legacy(type, id);
+	else
+		return image_type_hlsl_modern(type, id);
 }
 
 std::string CompilerHLSL::to_initializer_expression(const SPIRVariable &)


### PR DESCRIPTION
Replace the WEBMIN stubs for `CompilerHLSL::image_type_hlsl` and `CompilerHLSL::image_type_hlsl_legacy` with their real implementations (copied verbatim from the non-WEBMIN branch).

## Why

When `SPIRV_CROSS_WEBMIN` is defined, these two functions throw `"Invalid call."` instead of returning the HLSL type string for sampled images. They are reached on the very common path of emitting any `Texture2D` / `sampler2D` declaration — for example, the Babylon.js "Area Lights - PBR" code path which references `sampler2D` function parameters that get rewritten by Babylon Native's SPIR-V traverser.

The companion fix in Babylon Native (BabylonJS/BabylonNative#TBD, "split sampler2D function parameters" traverser) repairs the SPIR-V that previously crashed glslang, which means SPIRV-Cross is now actually invoked on this shader — and immediately hits the stub.

## What

`image_type_hlsl` already delegates to `image_type_hlsl_modern` (compiled unconditionally) or `image_type_hlsl_legacy`. This PR moves the real bodies of these two functions into the WEBMIN-enabled branch so the call chain works in WEBMIN builds.

Same un-guarding pattern as #11.

## Test

- Locally rebuilt Babylon Native with `SPIRV_CROSS_WEBMIN` on and the companion traverser fix; Playground visual test idx 194 ("Area Lights - PBR") now compiles and renders. Previously: `SPIRV_CROSS_THROW("Invalid call.")` at `spirv_hlsl.cpp:20234`.
- No behavior change for non-WEBMIN builds (real impls already present there).
