### PR TITLE
hlsl: flatten narrow inter-stage varying arrays into per-element members

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -1361,6 +1361,21 @@ std::string CompilerHLSL::to_semantic(uint32_t location, ExecutionModel em, Stor
 	return join("TEXCOORD", location);
 }
 
+// fxc rejects indexable input register ranges whose per-register write masks differ. This happens
+// for arrays of narrow (<4 component) inter-stage varyings: e.g. `float vDepthMetric[4]` becomes an
+// indexable TEXCOORD0..3 range whose scalar members get mismatched masks ("Masks on all input
+// registers in an index range must be identical"), which can hang fxc outright. Such arrays are
+// flattened into one interface member per element with consecutive semantics -- mirroring how
+// matrices are unrolled -- so no indexable range is emitted. float4[N] is unaffected (uniform masks).
+//
+// Only literal, non-zero sizes are flattened: a specialization-constant size is not known at
+// cross-compile time, and an unsized/runtime array has no element count to expand.
+static bool hlsl_is_flattened_varying_array(const SPIRType &type)
+{
+	return type.columns <= 1 && type.vecsize < 4 && type.array.size() == 1 &&
+	       type.array_size_literal.size() == 1 && type.array_size_literal[0] && type.array[0] != 0;
+}
+
 void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unordered_set<uint32_t> &active_locations)
 {
 	auto &execution = get_entry_point();
@@ -1443,13 +1458,37 @@ void CompilerHLSL::emit_interface_block_in_struct(const SPIRVariable &var, unord
 				decl_type.array.erase(decl_type.array.begin());
 				decl_type.array_size_literal.erase(decl_type.array_size_literal.begin());
 			}
-			statement(to_interpolation_qualifiers(get_decoration_bitset(var.self)), variable_decl(decl_type, name), " : ",
-			          semantic, ";");
 
-			// Structs and arrays should consume more locations.
-			uint32_t consumed_locations = type_to_consumed_locations(decl_type);
-			for (uint32_t i = 0; i < consumed_locations; i++)
-				active_locations.insert(location_number + i);
+			// See hlsl_is_flattened_varying_array: the global keeps its array type; only the
+			// interface struct is flattened (matching element-wise copies are emitted in
+			// emit_hlsl_entry_point).
+			bool interstage_varying =
+			    (execution.model == ExecutionModelVertex && var.storage == StorageClassOutput) ||
+			    (execution.model == ExecutionModelFragment && var.storage == StorageClassInput);
+			if (interstage_varying && hlsl_is_flattened_varying_array(decl_type))
+			{
+				uint32_t array_size = to_array_size_literal(decl_type);
+				SPIRType elem_type = decl_type;
+				elem_type.array.clear();
+				elem_type.array_size_literal.clear();
+				for (uint32_t i = 0; i < array_size; i++)
+				{
+					statement(to_interpolation_qualifiers(get_decoration_bitset(var.self)),
+					          variable_decl(elem_type, join(name, "_", i)), " : ",
+					          to_semantic(location_number + i, execution.model, var.storage), ";");
+					active_locations.insert(location_number + i);
+				}
+			}
+			else
+			{
+				statement(to_interpolation_qualifiers(get_decoration_bitset(var.self)), variable_decl(decl_type, name), " : ",
+				          semantic, ";");
+
+				// Structs and arrays should consume more locations.
+				uint32_t consumed_locations = type_to_consumed_locations(decl_type);
+				for (uint32_t i = 0; i < consumed_locations; i++)
+					active_locations.insert(location_number + i);
+			}
 		}
 	}
 	else
@@ -3314,7 +3353,18 @@ void CompilerHLSL::emit_hlsl_entry_point()
 				}
 				else
 				{
-					statement(name, " = stage_input.", name, ";");
+					// Match the interface-struct flattening of narrow inter-stage varying
+					// arrays (see hlsl_is_flattened_varying_array): copy element by element.
+					if (execution.model == ExecutionModelFragment && hlsl_is_flattened_varying_array(mtype))
+					{
+						uint32_t array_size = to_array_size_literal(mtype);
+						for (uint32_t i = 0; i < array_size; i++)
+							statement(name, "[", i, "] = stage_input.", name, "_", i, ";");
+					}
+					else
+					{
+						statement(name, " = stage_input.", name, ";");
+					}
 				}
 			}
 		}
@@ -3411,7 +3461,18 @@ void CompilerHLSL::emit_hlsl_entry_point()
 					}
 					else
 					{
-						statement("stage_output.", name, " = ", name, ";");
+						// Match the interface-struct flattening of narrow inter-stage varying
+						// arrays (see hlsl_is_flattened_varying_array): copy element by element.
+						if (execution.model == ExecutionModelVertex && hlsl_is_flattened_varying_array(type))
+						{
+							uint32_t array_size = to_array_size_literal(type);
+							for (uint32_t i = 0; i < array_size; i++)
+								statement("stage_output.", name, "_", i, " = ", name, "[", i, "];");
+						}
+						else
+						{
+							statement("stage_output.", name, " = ", name, ";");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Problem

Dynamically-indexed scalar/narrow (`vecsize < 4`) inter-stage varying arrays make SPIRV-Cross emit an **indexable HLSL input register range**. For example `float vDepthMetric[4]`, which Babylon.js emits for cascaded shadow maps, becomes `TEXCOORD0..3`.

fxc rejects such ranges when the per-register write masks differ:

```
X8000: masks on all input registers in an index range must be identical
```

In practice this does not merely fail — it **hangs fxc indefinitely** while compiling D3D11 CSM shaders, which stalls the whole build/run.

### Fix

Flatten these arrays into individual per-element interface members with consecutive semantics, mirroring the existing matrix-unroll path, so no indexable range is emitted.

- The global keeps its array type; only the *interface struct* is flattened.
- Matching element-wise copies are emitted in `emit_hlsl_entry_point` for both the vertex-output and fragment-input directions.
- `float4[N]` arrays are unaffected — their write masks are uniform, so they keep the existing indexable-range path.

Before:

```hlsl
struct SPIRV_Cross_Input { float vDepthMetric[4] : TEXCOORD0; };   // indexable range -> fxc hang
```

After:

```hlsl
struct SPIRV_Cross_Input
{
    float vDepthMetric_0 : TEXCOORD0;
    float vDepthMetric_1 : TEXCOORD1;
    float vDepthMetric_2 : TEXCOORD2;
    float vDepthMetric_3 : TEXCOORD3;
};
```

### Scope guards

Only **literal, non-zero** array sizes are flattened:

- A **specialization-constant** size is not known at cross-compile time (`to_array_size_literal` would silently bake in the spec constant's *default* value).
- An **unsized/runtime** array has no element count to expand.

Both keep the previous behavior. The predicate lives in one place (`hlsl_is_flattened_varying_array`) and is shared by all three call sites so the interface struct and the entry-point copies cannot drift apart.

### Testing

- Builds clean (MSVC 19.x, `/std:c++17`).
- Verified in situ through Babylon Native: `spirv-cross-hlsl` rebuilt and linked into the Playground, then the full Playground validation suite was run headless. The D3D11 CSM shader compile no longer hangs, and there is no change in results for shaders that do not hit the new path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
